### PR TITLE
Fix os specific pathing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -108,13 +108,13 @@ export async function createRedcapModule(options) {
  options = {
    ...options,   
    directoryName: '/' + options.moduleNameSC + '_v1.0.0',
-   targetDirectory: options.targetDirectory || process.cwd() + '\\' + options.moduleNameSC + '_v1.0.0'
+   targetDirectory: path.join(options.targetDirectory || process.cwd(), options.moduleNameSC + '_v1.0.0')
  };
 
  // Fix path for Windows
  const currentFileUrl = import.meta.url;
- const templateDir = path.resolve(
-    new URL(currentFileUrl).pathname.substring(new URL(currentFileUrl).pathname.indexOf('/')+1),
+ const templateDir = path.join(
+    new URL(currentFileUrl).pathname,
     '../../templates',
     options.template.toLowerCase()
   );


### PR DESCRIPTION
Running `npx create-redcap-module` on OSX failed with: `ERROR Invalid template name`. Using `path.join` handles pathing differences between Windows & OSX/Linux.